### PR TITLE
updated year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Jens Steube
+Copyright (c) 2015-2016 Jens Steube
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This small commit just updates the MIT license header by updating the year to "2015-2016".
Since it is already 2016, we should add this to the license file s.t. it is up-to-date.
Thx