### PR TITLE
LICENSE: increase year to 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Jens Steube
+Copyright (c) 2015-2018 Jens Steube
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 Jens Steube
+Copyright (c) 2015-2021 Jens Steube
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
this is a minor change. It only fixes the year within the "LICENSE" file. It should be 2018 right now (not 2016).

Happy new year.
Have a nice day

Thanks